### PR TITLE
Add examples of Select using a slice of q.Matcher

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"strings"
+	"time"
+
 	"github.com/asdine/storm"
 	"github.com/asdine/storm/q"
-	"log"
-	"time"
 )
 
 // Config type
@@ -86,6 +88,26 @@ func main() {
 	}
 	fmt.Println("Entries from Two Days Ago:")
 	fmt.Println(twoDaysAgo)
+
+	var data []Entry
+	var filters []q.Matcher
+	filters = append(filters, q.Eq("Calories", 300))
+	filters = append(filters, q.Eq("Food", "bread"))
+	err = db.Select(filters...).Bucket("Entry").Find(&data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println("Filtered bread using Select() will find data", data)
+
+	var data2 []Entry
+	var filters2 []q.Matcher
+	filters2 = append(filters2, q.Eq("Calories", 50))
+	filters2 = append(filters2, q.Eq("Food", "bread"))
+	err = db.Select(filters2...).Bucket("Entry").Find(&data2)
+	if err != nil && strings.Index(err.Error(), "not found") == -1 {
+		log.Fatal(err)
+	}
+	log.Println("Filtered bread using Select() will not find data because the calories should match nothing", data2)
 }
 
 func addConfig(db *storm.DB, height float64, birthday time.Time) error {


### PR DESCRIPTION
I wanted to add some examples showing how conditionally someone could append various q.Matchers to a filter slice and showing you that err is thrown when no data is found on a Find.  This is a helpful example to see how to compose a query where logic in your algorithm will append filters based on various conditions since technically it seems like you can only call Select once to build the And's and cannot modify it after.  The slice example is how I am going to need implement things because not all my callers will know 100% the full filter when it's executed so it needs to be built up over time and then the slice of q.Matcher is passed to Select().

In this case of the data2 block, if I merely re-used data, the records would still exist because when storm cant find anything, it keeps your referenced data in there and doesnt clear it.  So anyone using this, make sure you handle errors like I did with the "not found" check so that you typically wont want to return error back on a not found when filtering data, rather just pass back the empty slice of data back to your caller who is making the query.